### PR TITLE
Add support for hexadecimal input

### DIFF
--- a/color-picker-view/src/main/java/com/github/danielnilsson9/colorpickerview/ColorUtils.java
+++ b/color-picker-view/src/main/java/com/github/danielnilsson9/colorpickerview/ColorUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015 Daniel Nilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.danielnilsson9.colorpickerview;
+
+import android.graphics.Color;
+
+import java.util.regex.Pattern;
+
+public class ColorUtils {
+    /** Format for #AARRGGBB and #RRGGBB. **/
+    private final static Pattern HEXADECIMAL_FORMAT = Pattern.compile("^#([A-Fa-f0-9]{8}|[A-Fa-f0-9]{6})$");
+    /** Format for #RGB **/
+    private final static Pattern HEXADECIMAL_SHORT_FORMAT = Pattern.compile("^#([A-Fa-f0-9]{3})$");
+
+    /**
+     * Check if the provided color code is valid according to the following hexadecimal color formats:
+     *      #AARRGGBB, #RRGGBB or #RGB.
+     * @param colorCode color code to check
+     * @return {@code true} color code is valid according to the formats
+     */
+    public static boolean isValidHexadecimal(String colorCode) {
+        return HEXADECIMAL_FORMAT.matcher(colorCode).matches() ||
+                HEXADECIMAL_SHORT_FORMAT.matcher(colorCode).matches();
+    }
+
+    /**
+     * Parse the color code, and return the corresponding color-int.
+     * If the string cannot be parsed, throws an IllegalArgumentException
+     * exception. Supported formats are:
+     * #RRGGBB
+     * #AARRGGBB
+     * #RGB
+     * @param colorCode color code to parse
+     * @return color-int
+     */
+    public static int parseColor(String colorCode) {
+        if (HEXADECIMAL_SHORT_FORMAT.matcher(colorCode).matches()) {
+            colorCode = String.format("#%c%c%c%c%c%c", colorCode.charAt(1), colorCode.charAt(1),
+                    colorCode.charAt(2), colorCode.charAt(2), colorCode.charAt(3), colorCode.charAt(3));
+        }
+        return Color.parseColor(colorCode);
+    }
+
+    /**
+     * Convert a color-int into a color hexadecimal string.
+     * Format will be #AARRGGBB if includeAlpha is true, or #RRGGBB if is false.
+     *
+     * @param color color int
+     * @param includeAlpha if true hexadecimal will include alpha channel
+     * @return color code for the color-int specified and based on the includeAlpha
+     */
+    public static String colorToString(int color, boolean includeAlpha) {
+        if (includeAlpha) {
+            return "#" + Integer.toHexString(color);
+        } else {
+            return "#" + Integer.toHexString(color).substring(2);
+        }
+    }
+}

--- a/color-picker-view/src/main/java/com/github/danielnilsson9/colorpickerview/dialog/ColorPickerDialogFragment.java
+++ b/color-picker-view/src/main/java/com/github/danielnilsson9/colorpickerview/dialog/ColorPickerDialogFragment.java
@@ -24,6 +24,9 @@ import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.text.Editable;
+import android.text.InputFilter;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -31,9 +34,14 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.Button;
+import android.widget.EditText;
 import android.widget.TextView;
 
+import com.github.danielnilsson9.colorpickerview.ColorUtils;
+
 public class ColorPickerDialogFragment extends DialogFragment {
+
+    private static final String ARG_HEXADECIMAL_INPUT = "hexadecimal_input";
 
 	public interface ColorPickerDialogListener {
 		public void onColorSelected(int dialogId, int color);
@@ -47,16 +55,27 @@ public class ColorPickerDialogFragment extends DialogFragment {
 	private ColorPanelView mOldColorPanel;
 	private ColorPanelView mNewColorPanel;
 	private Button mOkButton;
-	
+    private EditText mHexadecimalInput;
+	private boolean mSkipHexadecimalTextChange;
+
 	private ColorPickerDialogListener mListener;
-	
-	
-	public static ColorPickerDialogFragment newInstance(int dialogId, int initialColor) {
-		return newInstance(dialogId, null, null, initialColor, false);
-	}
-	
+
+
+    public static ColorPickerDialogFragment newInstance(int dialogId, int initialColor) {
+        return newInstance(dialogId, null, null, initialColor, false);
+    }
+
+    public static ColorPickerDialogFragment newInstance(int dialogId, int initialColor, boolean showHexadecimalInput) {
+        return newInstance(dialogId, null, null, initialColor, false, showHexadecimalInput);
+    }
+
+    public static ColorPickerDialogFragment newInstance(
+            int dialogId, String title, String okButtonText, int initialColor, boolean showAlphaSlider) {
+        return newInstance(dialogId, title, okButtonText, initialColor, showAlphaSlider, false);
+    }
+
 	public static ColorPickerDialogFragment newInstance(
-			int dialogId, String title, String okButtonText, int initialColor, boolean showAlphaSlider) {
+			int dialogId, String title, String okButtonText, int initialColor, boolean showAlphaSlider, boolean showHexadecimalInput) {
 		
 		ColorPickerDialogFragment frag = new ColorPickerDialogFragment();
 		Bundle args = new Bundle();
@@ -65,7 +84,8 @@ public class ColorPickerDialogFragment extends DialogFragment {
 		args.putString("ok_button", okButtonText);
 		args.putBoolean("alpha", showAlphaSlider);
 		args.putInt("init_color", initialColor);
-		
+		args.putBoolean(ARG_HEXADECIMAL_INPUT, showHexadecimalInput);
+
 		frag.setArguments(args);
 		
 		return frag;
@@ -114,9 +134,10 @@ public class ColorPickerDialogFragment extends DialogFragment {
 	public View onCreateView(LayoutInflater inflater, ViewGroup container,
 			Bundle savedInstanceState) {
 		View v = inflater.inflate(R.layout.colorpickerview__dialog_color_picker, container);
-		
-	
-		TextView titleView = (TextView) v.findViewById(android.R.id.title);
+
+        final boolean showHexadecimalInput = getArguments().getBoolean(ARG_HEXADECIMAL_INPUT);
+        final boolean showAlphaSlider = getArguments().getBoolean("alpha");
+        TextView titleView = (TextView) v.findViewById(android.R.id.title);
 		
 		mColorPicker = (ColorPickerView) 
 				v.findViewById(R.id.colorpickerview__color_picker_view);
@@ -125,12 +146,17 @@ public class ColorPickerDialogFragment extends DialogFragment {
 		mNewColorPanel = (ColorPanelView) 
 				v.findViewById(R.id.colorpickerview__color_panel_new);
 		mOkButton = (Button) v.findViewById(android.R.id.button1);
-		
+        mHexadecimalInput = (EditText) v.findViewById(R.id.colorpickerview__hexadecimal_input);
 
 		mColorPicker.setOnColorChangedListener(new OnColorChangedListener() {
 			
 			@Override
 			public void onColorChanged(int newColor) {
+                if (showHexadecimalInput) {
+                    String hexadecimalColor = ColorUtils.colorToString(newColor, showAlphaSlider);
+                    mSkipHexadecimalTextChange = true;
+                    mHexadecimalInput.setText(hexadecimalColor);
+                }
 				mNewColorPanel.setColor(newColor);
 			}
 		});
@@ -157,15 +183,42 @@ public class ColorPickerDialogFragment extends DialogFragment {
 		
 			
 		if(savedInstanceState == null) {
-			mColorPicker.setAlphaSliderVisible(
-					getArguments().getBoolean("alpha"));
-			
+			mColorPicker.setAlphaSliderVisible(showAlphaSlider);
 			
 			String ok = getArguments().getString("ok_button");
 			if(ok != null) {
 				mOkButton.setText(ok);
 			}
-			
+
+            mHexadecimalInput.setVisibility(showHexadecimalInput? View.VISIBLE: View.GONE);
+            if (showHexadecimalInput) {
+                int maxCharCount = showAlphaSlider? 9: 7;
+                mHexadecimalInput.setFilters(new InputFilter[] {new InputFilter.LengthFilter(maxCharCount)});
+
+                mHexadecimalInput.addTextChangedListener(new TextWatcher() {
+                    @Override
+                    public void beforeTextChanged(CharSequence s, int start, int count, int after) { }
+
+                    @Override
+                    public void onTextChanged(CharSequence s, int start, int before, int count) { }
+
+                    @Override
+                    public void afterTextChanged(Editable s) {
+                        if (mSkipHexadecimalTextChange) {
+                            mSkipHexadecimalTextChange = false;
+                        } else {
+                            if (s.length() == 0 || s.charAt(0) != '#') {
+                                s.insert(0, "#");
+                            } else if (ColorUtils.isValidHexadecimal(s.toString())) {
+                                int color = ColorUtils.parseColor(s.toString());
+                                mColorPicker.setColor(color);
+                                mNewColorPanel.setColor(color);
+                            }
+                        }
+                    }
+                });
+            }
+
 			int initColor = getArguments().getInt("init_color");
 			
 			mOldColorPanel.setColor(initColor);

--- a/color-picker-view/src/main/java/com/github/danielnilsson9/colorpickerview/dialog/ColorPickerDialogFragment.java
+++ b/color-picker-view/src/main/java/com/github/danielnilsson9/colorpickerview/dialog/ColorPickerDialogFragment.java
@@ -61,20 +61,24 @@ public class ColorPickerDialogFragment extends DialogFragment {
 	private ColorPickerDialogListener mListener;
 
 
+    /**
+     * @deprecated replaced by {@link Builder}
+     */
+    @Deprecated
     public static ColorPickerDialogFragment newInstance(int dialogId, int initialColor) {
         return newInstance(dialogId, null, null, initialColor, false);
     }
 
-    public static ColorPickerDialogFragment newInstance(int dialogId, int initialColor, boolean showHexadecimalInput) {
-        return newInstance(dialogId, null, null, initialColor, false, showHexadecimalInput);
-    }
-
+    /**
+     * @deprecated replaced by {@link Builder}
+     */
+    @Deprecated
     public static ColorPickerDialogFragment newInstance(
             int dialogId, String title, String okButtonText, int initialColor, boolean showAlphaSlider) {
         return newInstance(dialogId, title, okButtonText, initialColor, showAlphaSlider, false);
     }
 
-	public static ColorPickerDialogFragment newInstance(
+	private static ColorPickerDialogFragment newInstance(
 			int dialogId, String title, String okButtonText, int initialColor, boolean showAlphaSlider, boolean showHexadecimalInput) {
 		
 		ColorPickerDialogFragment frag = new ColorPickerDialogFragment();
@@ -236,4 +240,45 @@ public class ColorPickerDialogFragment extends DialogFragment {
 		mListener.onDialogDismissed(mDialogId);
 	}
 
+
+    /**
+     * Builder class for ColorPickerDialogFragment.
+     */
+    public static class Builder {
+        private final int dialogId;
+        private final int initialColor;
+        private String okButtonText;
+        private String title;
+        private boolean showAlphaSlider;
+        private boolean showHexadecimalInput;
+
+        public Builder(int dialogId, int initialColor) {
+            this.dialogId = dialogId;
+            this.initialColor = initialColor;
+        }
+
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public Builder okButtonText(String text) {
+            this.okButtonText = text;
+            return this;
+        }
+
+        public Builder showAlphaSlider(boolean show) {
+            this.showAlphaSlider = show;
+            return this;
+        }
+
+        public Builder showHexadecimalInput(boolean show) {
+            this.showHexadecimalInput = show;
+            return this;
+        }
+
+        public ColorPickerDialogFragment build() {
+            return ColorPickerDialogFragment.newInstance(dialogId, title, okButtonText, initialColor, showAlphaSlider, showHexadecimalInput);
+        }
+    }
 }

--- a/color-picker-view/src/main/res/layout/colorpickerview__dialog_color_picker.xml
+++ b/color-picker-view/src/main/res/layout/colorpickerview__dialog_color_picker.xml
@@ -19,10 +19,25 @@
         android:gravity="center_horizontal"
         android:orientation="horizontal" >
 
-        <com.github.danielnilsson9.colorpickerview.view.ColorPickerView
-            android:id="@id/colorpickerview__color_picker_view"
-            style="@style/colorpickerview__ColorPickerViewStyle"
-            android:padding="16dp" />
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.github.danielnilsson9.colorpickerview.view.ColorPickerView
+                android:id="@id/colorpickerview__color_picker_view"
+                style="@style/colorpickerview__ColorPickerViewStyle"
+                android:padding="16dp" />
+
+            <EditText
+                android:id="@+id/colorpickerview__hexadecimal_input"
+                android:hint="@string/colorpickerview__hexadecimal_input"
+                android:imeOptions="actionDone"
+                android:maxLines="1"
+                android:digits="#0123456789AaBbCcDdEeFf"
+                style="@style/colorpickerview__HexadecimalInput"/>
+
+        </LinearLayout>
 
         <FrameLayout
             android:layout_width="wrap_content"

--- a/color-picker-view/src/main/res/values/ids.xml
+++ b/color-picker-view/src/main/res/values/ids.xml
@@ -4,5 +4,5 @@
     <item type="id" name="colorpickerview__color_panel_old" />
     <item type="id" name="colorpickerview__color_panel_new" />
     <item type="id" name="colorpickerview__preference_preview_color_panel" />
-
+    <item type="id" name="colorpickerview__hexadecimal_input"/>
 </resources>

--- a/color-picker-view/src/main/res/values/strings.xml
+++ b/color-picker-view/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="colorpickerview__hexadecimal_input">Hexadecimal</string>
+</resources>

--- a/color-picker-view/src/main/res/values/styles.xml
+++ b/color-picker-view/src/main/res/values/styles.xml
@@ -5,6 +5,13 @@
         <item name="android:layout_height">wrap_content</item>
     </style>
 
+    <style name="colorpickerview__HexadecimalInput">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginLeft">16dp</item>
+        <item name="android:layout_marginRight">16dp</item>
+        <item name="android:layout_marginBottom">8dp</item>
+    </style>
     
     <!-- Custom button style quite close to the one foind in material design. (borderless) -->
     <style name="colorpickerview__PickerDialogButtonStyle">

--- a/demo/src/main/java/com/github/danielnilsson9/colorpickerview/demo/MainActivity.java
+++ b/demo/src/main/java/com/github/danielnilsson9/colorpickerview/demo/MainActivity.java
@@ -70,7 +70,7 @@ public class MainActivity extends Activity implements ColorPickerDialogListener 
 		// a dialog using the custom ColorPickerDialogFragment class.
 		
 		ColorPickerDialogFragment f = ColorPickerDialogFragment
-				.newInstance(DIALOG_ID, null, null, Color.BLACK, true);
+				.newInstance(DIALOG_ID, null, null, Color.BLACK, true, true);
 		
 		f.setStyle(DialogFragment.STYLE_NORMAL, R.style.LightPickerDialogTheme);
 		f.show(getFragmentManager(), "d");
@@ -142,7 +142,7 @@ public class MainActivity extends Activity implements ColorPickerDialogListener 
 					
 					// Preference was clicked, we need to show the dialog.					
 					ColorPickerDialogFragment dialog = ColorPickerDialogFragment
-							.newInstance(PREFERENCE_DIALOG_ID, "Color Picker", null, currentColor, false);
+							.newInstance(PREFERENCE_DIALOG_ID, "Color Picker", null, currentColor, false, true);
 
 					dialog.setStyle(DialogFragment.STYLE_NORMAL, R.style.LightPickerDialogTheme);
 					

--- a/demo/src/main/java/com/github/danielnilsson9/colorpickerview/demo/MainActivity.java
+++ b/demo/src/main/java/com/github/danielnilsson9/colorpickerview/demo/MainActivity.java
@@ -68,10 +68,10 @@ public class MainActivity extends Activity implements ColorPickerDialogListener 
 		
 		// The color picker menu item has been clicked. Show 
 		// a dialog using the custom ColorPickerDialogFragment class.
-		
-		ColorPickerDialogFragment f = ColorPickerDialogFragment
-				.newInstance(DIALOG_ID, null, null, Color.BLACK, true, true);
-		
+        ColorPickerDialogFragment f = new ColorPickerDialogFragment.Builder(DIALOG_ID, Color.BLACK)
+                .showAlphaSlider(true)
+                .showHexadecimalInput(true).build();
+
 		f.setStyle(DialogFragment.STYLE_NORMAL, R.style.LightPickerDialogTheme);
 		f.show(getFragmentManager(), "d");
 
@@ -141,8 +141,9 @@ public class MainActivity extends Activity implements ColorPickerDialogListener 
 				public void onShowColorPickerDialog(String title, int currentColor) {
 					
 					// Preference was clicked, we need to show the dialog.					
-					ColorPickerDialogFragment dialog = ColorPickerDialogFragment
-							.newInstance(PREFERENCE_DIALOG_ID, "Color Picker", null, currentColor, false, true);
+					ColorPickerDialogFragment dialog = new ColorPickerDialogFragment.Builder(PREFERENCE_DIALOG_ID, currentColor)
+                            .title("Color Picker")
+                            .showHexadecimalInput(true).build();
 
 					dialog.setStyle(DialogFragment.STYLE_NORMAL, R.style.LightPickerDialogTheme);
 					


### PR DESCRIPTION
This changes allow the user to insert hexadecimal color codes, as requested on #8 .
I have added an EditText to the ColorPickerDialogFragment which can be activated/deactivated by a new parameter of the fragment.
The hexadecimal input depends on the availability of the alpha slider.

To improve the building of the fragment I've added a Builder to the ColorPickerDialogFragment and deprecated the current way of building the fragment, although it would still work.

I've taken care of backward compatibility so that user's of the previous version of the library will keep their behaviour when updating.
